### PR TITLE
ecp5ddrphy: Reliability improvements

### DIFF
--- a/ecp5ddrphy.py
+++ b/ecp5ddrphy.py
@@ -164,7 +164,6 @@ class ECP5DDRPHY(Module, AutoCSR):
         oe_dq = Signal()
         oe_dqs = Signal()
 
-
         global_datavalid = Signal()
         global_readposition = Signal(7)
         ddrdel = Signal()
@@ -407,10 +406,10 @@ class ECP5DDRPHY(Module, AutoCSR):
                 dq_bitslip_o_d = Signal(4)
                 self.sync += dq_bitslip_o_d.eq(dq_bitslip.o)
                 self.comb += [
-                    self.dfi.phases[0].rddata[0*databits+j].eq(dq_bitslip_o_d[3]), self.dfi.phases[0].rddata[1*databits+j].eq(dq_bitslip_o_d[2]),
-                    self.dfi.phases[0].rddata[2*databits+j].eq(dq_bitslip_o_d[1]), self.dfi.phases[0].rddata[3*databits+j].eq(dq_bitslip_o_d[0]),
-                    self.dfi.phases[1].rddata[0*databits+j].eq(dq_bitslip.o[3]), self.dfi.phases[1].rddata[1*databits+j].eq(dq_bitslip.o[2]),
-                    self.dfi.phases[1].rddata[2*databits+j].eq(dq_bitslip.o[1]), self.dfi.phases[1].rddata[3*databits+j].eq(dq_bitslip.o[0]),
+                    self.dfi.phases[0].rddata[0*databits+j].eq(dq_bitslip_o_d[0]), self.dfi.phases[0].rddata[1*databits+j].eq(dq_bitslip_o_d[1]),
+                    self.dfi.phases[0].rddata[2*databits+j].eq(dq_bitslip_o_d[2]), self.dfi.phases[0].rddata[3*databits+j].eq(dq_bitslip_o_d[3]),
+                    self.dfi.phases[1].rddata[0*databits+j].eq(dq_bitslip.o[0]), self.dfi.phases[1].rddata[1*databits+j].eq(dq_bitslip.o[1]),
+                    self.dfi.phases[1].rddata[2*databits+j].eq(dq_bitslip.o[2]), self.dfi.phases[1].rddata[3*databits+j].eq(dq_bitslip.o[3]),
                 ]
                 self.specials += \
                     Instance("TSHX2DQA",
@@ -455,5 +454,4 @@ class ECP5DDRPHY(Module, AutoCSR):
             ).Else(
                 oe_dqs.eq(oe), oe_dq.eq(oe)
             )
-
         self.sync += bl8_sel.eq(last_wrdata_en[cwl_sys_latency-1])

--- a/ecp5ddrphy.py
+++ b/ecp5ddrphy.py
@@ -196,7 +196,7 @@ class ECP5DDRPHY(Module, AutoCSR):
                 i_ECLK=ClockSignal("sys2x"),
                 i_RST=ResetSignal(),
                 i_DDRDEL=ddrdel,
-                i_PAUSE=~ddrdel_lock,
+                i_PAUSE=~ddrdel_lock | self._dly_sel.storage[i],
 
                 # Control
                 # Assert LOADNs to use DDRDEL control
@@ -208,11 +208,11 @@ class ECP5DDRPHY(Module, AutoCSR):
                 i_WRDIRECTION=1,
 
                 # Reads (generate shifted DQS clock for reads)
-                i_READ0=1,
-                i_READ1=1,
-                i_READCLKSEL0=readclksel[0],
-                i_READCLKSEL1=readclksel[1],
-                i_READCLKSEL2=readclksel[2],
+                i_READ0=~self._dly_sel.storage[i],
+                i_READ1=~self._dly_sel.storage[i],
+                i_READCLKSEL0=0,
+                i_READCLKSEL1=0,
+                i_READCLKSEL2=1,
                 i_DQSI=pads.dqs_p[i],
                 o_DQSR90=dqsr90,
                 o_RDPNTR0=rdpntr[0],
@@ -339,8 +339,8 @@ class ECP5DDRPHY(Module, AutoCSR):
                 self.specials += \
                     Instance("DELAYF",
                         i_A=pads.dq[j],
-                        i_LOADN=1,
-                        i_MOVE=0,
+                        i_LOADN=~(self._dly_sel.storage[i//8] & self._rdly_dq_rst.re),
+                        i_MOVE=self._dly_sel.storage[i//8] & self._rdly_dq_inc.re,
                         i_DIRECTION=0,
                         o_Z=dq_i_delay,
                         p_DEL_MODE="DQS_ALIGNED_X2"

--- a/ecp5ddrphy.py
+++ b/ecp5ddrphy.py
@@ -66,7 +66,7 @@ class ECP5DDRPHY(Module, AutoCSR):
         self._wdly_dqs_inc = CSR()
 
         self._burstdet_rst = CSR()
-        self._burstdet_count = CSRStatus(8)
+        self._burstdet_found = CSRStatus()
 
         # PHY settings -----------------------------------------------------------------------------
         cl, cwl = get_cl_cw(memtype, tck)
@@ -255,9 +255,9 @@ class ECP5DDRPHY(Module, AutoCSR):
                 self.sync += burstdet_d.eq(burstdet)
                 self.sync += [
                     If(self._burstdet_rst.re,
-                        self._burstdet_count.status.eq(0)
-                    ).Elif(burstdet != burstdet_d,
-                        self._burstdet_count.status.eq(self._burstdet_count.status + 1)
+                        self._burstdet_found.status.eq(0)
+                    ).Elif(burstdet & ~burstdet_d,
+                        self._burstdet_found.status.eq(1)
                     )
                 ]
 
@@ -377,7 +377,7 @@ class ECP5DDRPHY(Module, AutoCSR):
                         o_Z=dq_i_delay,
                         p_DEL_MODE="DQS_ALIGNED_X2"
                     )
-                
+
                 self.specials += \
                     Instance("IDDRX2DQA",
                         i_D=dq_i_delay,

--- a/ecp5ddrphy.py
+++ b/ecp5ddrphy.py
@@ -278,7 +278,7 @@ class ECP5DDRPHY(Module, AutoCSR):
                 self.dfi.phases[1].wrdata_mask[2*databits//8+i], self.dfi.phases[1].wrdata_mask[3*databits//8+i]),
             )
             self.sync += dm_data_d.eq(dm_data)
-            self.comb += \
+            self.sync += \
                 If(bl8_sel,
                     dm_data_muxed.eq(dm_data_d[4:])
                 ).Else(
@@ -337,7 +337,7 @@ class ECP5DDRPHY(Module, AutoCSR):
                     self.dfi.phases[1].wrdata[2*databits+j], self.dfi.phases[1].wrdata[3*databits+j])
                 )
                 self.sync += dq_data_d.eq(dq_data)
-                self.comb += \
+                self.sync += \
                     If(bl8_sel,
                         dq_data_muxed.eq(dq_data_d[4:])
                     ).Else(
@@ -356,9 +356,25 @@ class ECP5DDRPHY(Module, AutoCSR):
                         o_Q=dq_o
                     )
                 dq_i_data = Signal(4)
+
+
+                dq_i_delay = Signal()
+
+                self.specials += \
+                    Instance("DELAYF",
+                        i_A=pads.dq[j],
+                        #i_LOADN=~(self._dly_sel.storage[i//8] & self._rdly_dq_rst.re),
+                        #i_MOVE=self._dly_sel.storage[i//8] & self._rdly_dq_inc.re,
+                        i_LOADN=1,
+                        i_MOVE=0,
+                        i_DIRECTION=0,
+                        o_Z=dq_i_delay,
+                        p_DEL_MODE="DQS_ALIGNED_X2"
+                    )
+                
                 self.specials += \
                     Instance("IDDRX2DQA",
-                        i_D=pads.dq[j],
+                        i_D=dq_i_delay,
                         i_RST=ResetSignal(),
                         i_DQSR90=dqsr90,
                         i_SCLK=ClockSignal(),

--- a/ecp5ddrphy.py
+++ b/ecp5ddrphy.py
@@ -173,7 +173,7 @@ class ECP5DDRPHY(Module, AutoCSR):
             i_CLK=ClockSignal("sys2x"),
             i_RST=ResetSignal(),
             i_UDDCNTLN=~self._rdly_dq_rst.re,
-            i_FREEZE=0,
+            i_FREEZE=ddrdel_lock,
             o_DDRDEL=ddrdel,
             o_LOCK=ddrdel_lock
         )
@@ -304,7 +304,7 @@ class ECP5DDRPHY(Module, AutoCSR):
                     i_D1=dqs_serdes_pattern[1],
                     i_D2=dqs_serdes_pattern[2],
                     i_D3=dqs_serdes_pattern[3],
-                    i_RST=ResetSignal(),
+                    i_RST=ResetSignal() | ~ddrdel_lock,
                     i_DQSW=dqsw,
                     i_ECLK=ClockSignal("sys2x"),
                     i_SCLK=ClockSignal(),
@@ -317,7 +317,7 @@ class ECP5DDRPHY(Module, AutoCSR):
                     i_SCLK=ClockSignal(),
                     i_ECLK=ClockSignal("sys2x"),
                     i_DQSW=dqsw,
-                    i_RST=ResetSignal(),
+                    i_RST=ResetSignal() | ~ddrdel_lock,
                     o_Q=dqs_oe_n,
                 )
             self.specials += Tristate(pads.dqs_p[i], dqs, ~dqs_oe_n)
@@ -348,7 +348,7 @@ class ECP5DDRPHY(Module, AutoCSR):
                         i_D1=dq_data_muxed[1],
                         i_D2=dq_data_muxed[2],
                         i_D3=dq_data_muxed[3],
-                        i_RST=ResetSignal(),
+                        i_RST=ResetSignal() | ~ddrdel_lock,
                         i_DQSW270=dqsw270,
                         i_ECLK=ClockSignal("sys2x"),
                         i_SCLK=ClockSignal(),
@@ -374,7 +374,7 @@ class ECP5DDRPHY(Module, AutoCSR):
                 self.specials += \
                     Instance("IDDRX2DQA",
                         i_D=dq_i_delay,
-                        i_RST=ResetSignal(),
+                        i_RST=ResetSignal() | ~ddrdel_lock,
                         i_DQSR90=dqsr90,
                         i_SCLK=ClockSignal(),
                         i_ECLK=ClockSignal("sys2x"),
@@ -418,7 +418,7 @@ class ECP5DDRPHY(Module, AutoCSR):
                         i_SCLK=ClockSignal(),
                         i_ECLK=ClockSignal("sys2x"),
                         i_DQSW270=dqsw270,
-                        i_RST=ResetSignal(),
+                        i_RST=ResetSignal() | ~ddrdel_lock,
                         o_Q=dq_oe_n,
                     )
                 self.specials += Tristate(pads.dq[j], dq_o, ~dq_oe_n)

--- a/ecp5ddrphy.py
+++ b/ecp5ddrphy.py
@@ -342,11 +342,8 @@ class ECP5DDRPHY(Module, AutoCSR):
                         i_SCLK=ClockSignal(),
                         o_Q=dq_o
                     )
-                dq_i_data = Signal(8)
-                dq_i_data_d = Signal(8)
-
-                dq_i_delay = Signal()
-
+                dq_i_delayed = Signal()
+                dq_i_data = Signal(4)
                 self.specials += \
                     Instance("DELAYF",
                         i_A=pads.dq[j],
@@ -355,22 +352,22 @@ class ECP5DDRPHY(Module, AutoCSR):
                         i_LOADN=1,
                         i_MOVE=0,
                         i_DIRECTION=0,
-                        o_Z=dq_i_delay,
+                        o_Z=dq_i_delayed,
                         p_DEL_MODE="DQS_ALIGNED_X2"
                     )
                 self.specials += \
                     Instance("IDDRX2DQA",
-                        i_D=dq_i_delay,
+                        i_D=dq_i_delayed,
                         i_RST=ResetSignal(),
                         i_DQSR90=dqsr90,
                         i_SCLK=ClockSignal(),
                         i_ECLK=ClockSignal("sys2x"),
-                        i_RDPNTR0=rdpntr[0], # CHECKME: are RDPNTR/WRPTNR
-                        i_RDPNTR1=rdpntr[1], # behaving correctly when
-                        i_RDPNTR2=rdpntr[2], # READ_0/READCLKSEL signals
-                        i_WRPNTR0=wrpntr[0], # are not used. It should be
-                        i_WRPNTR1=wrpntr[1], # be the case but needs to be
-                        i_WRPNTR2=wrpntr[2], # verified.
+                        i_RDPNTR0=rdpntr[0],
+                        i_RDPNTR1=rdpntr[1],
+                        i_RDPNTR2=rdpntr[2],
+                        i_WRPNTR0=wrpntr[0],
+                        i_WRPNTR1=wrpntr[1],
+                        i_WRPNTR2=wrpntr[2],
                         o_Q0=dq_i_data[0],
                         o_Q1=dq_i_data[1],
                         o_Q2=dq_i_data[2],

--- a/ecp5ddrphy.py
+++ b/ecp5ddrphy.py
@@ -211,9 +211,9 @@ class ECP5DDRPHY(Module, AutoCSR):
                 # Reads (generate shifted DQS clock for reads)
                 i_READ0=dqs_read,
                 i_READ1=dqs_read,
-                i_READCLKSEL0=1,
-                i_READCLKSEL1=1,
-                i_READCLKSEL2=0,
+                i_READCLKSEL0=readclksel[0],
+                i_READCLKSEL1=readclksel[1],
+                i_READCLKSEL2=readclksel[2],
                 i_DQSI=pads.dqs_p[i],
                 o_DQSR90=dqsr90,
                 o_RDPNTR0=rdpntr[0],
@@ -340,8 +340,10 @@ class ECP5DDRPHY(Module, AutoCSR):
                 self.specials += \
                     Instance("DELAYF",
                         i_A=pads.dq[j],
-                        i_LOADN=~(self._dly_sel.storage[i//8] & self._rdly_dq_rst.re),
-                        i_MOVE=self._dly_sel.storage[i//8] & self._rdly_dq_inc.re,
+                        #i_LOADN=~(self._dly_sel.storage[i//8] & self._rdly_dq_rst.re),
+                        #i_MOVE=self._dly_sel.storage[i//8] & self._rdly_dq_inc.re,
+                        i_LOADN=1,
+                        i_MOVE=0,
                         i_DIRECTION=0,
                         o_Z=dq_i_delay,
                         p_DEL_MODE="DQS_ALIGNED_X2"
@@ -412,12 +414,7 @@ class ECP5DDRPHY(Module, AutoCSR):
             rddata_en = n_rddata_en
         self.sync += [phase.rddata_valid.eq(rddata_en | self._wlevel_en.storage)
             for phase in self.dfi.phases]
-        self.sync += \
-            If(rddata_ens != 0,
-                dqs_read.eq(1)
-            ).Else(
-                dqs_read.eq(0)
-            )
+        self.sync += dqs_read.eq(rddata_ens[3] | rddata_ens[4])
         oe = Signal()
         last_wrdata_en = Signal(cwl_sys_latency+3)
         wrphase = self.dfi.phases[self.settings.wrphase]

--- a/ecp5ddrphy.py
+++ b/ecp5ddrphy.py
@@ -171,6 +171,7 @@ class ECP5DDRPHY(Module, AutoCSR):
         ddrdel = Signal()
         ddrdel_lock = Signal()
         dqs_read = Signal()
+
         self.specials += Instance("DDRDLLA",
             i_CLK=ClockSignal("sys2x"),
             i_RST=ResetSignal(),
@@ -212,7 +213,7 @@ class ECP5DDRPHY(Module, AutoCSR):
                 i_ECLK=ClockSignal("sys2x"),
                 i_RST=ResetSignal(),
                 i_DDRDEL=ddrdel,
-                i_PAUSE=~ddrdel_lock,
+                i_PAUSE=~ddrdel_lock | self._dly_sel.storage[i],
 
                 # Control
                 # Assert LOADNs to use DDRDEL control

--- a/ecp5ddrphy.py
+++ b/ecp5ddrphy.py
@@ -390,12 +390,13 @@ class ECP5DDRPHY(Module, AutoCSR):
                         )
                     )
                 self.submodules += dq_bitslip
-                self.sync += dq_i_data_d.eq(dq_i_data)
+                dq_bitslip_o_d = Signal(4)
+                self.sync += dq_bitslip_o_d.eq(dq_bitslip.o)
                 self.comb += [
-                    self.dfi.phases[0].rddata[j].eq(dq_bitslip.o[0]),
-                    self.dfi.phases[0].rddata[databits+j].eq(dq_bitslip.o[1]),
-                    self.dfi.phases[1].rddata[j].eq(dq_bitslip.o[2]),
-                    self.dfi.phases[1].rddata[databits+j].eq(dq_bitslip.o[3])
+                    self.dfi.phases[0].rddata[0*databits+j].eq(dq_bitslip_o_d[3]), self.dfi.phases[0].rddata[1*databits+j].eq(dq_bitslip_o_d[2]),
+                    self.dfi.phases[0].rddata[2*databits+j].eq(dq_bitslip_o_d[1]), self.dfi.phases[0].rddata[3*databits+j].eq(dq_bitslip_o_d[0]),
+                    self.dfi.phases[1].rddata[0*databits+j].eq(dq_bitslip.o[3]), self.dfi.phases[1].rddata[1*databits+j].eq(dq_bitslip.o[2]),
+                    self.dfi.phases[1].rddata[2*databits+j].eq(dq_bitslip.o[1]), self.dfi.phases[1].rddata[3*databits+j].eq(dq_bitslip.o[0]),
                 ]
                 self.specials += \
                     Instance("TSHX2DQA",

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -10,7 +10,7 @@ wb.open()
 # # #
 
 analyzer = LiteScopeAnalyzerDriver(wb.regs, "analyzer", debug=True)
-analyzer.configure_trigger(cond={"dfi_p0_cas_n": 0})
+analyzer.configure_trigger(cond={"ecp5ddrphy_dfi_p0_rddata_valid": 1})
 analyzer.run(offset=32, length=128)
 analyzer.wait_done()
 analyzer.upload()

--- a/test/test_sdram.py
+++ b/test/test_sdram.py
@@ -13,8 +13,8 @@ wb.open()
 # Tests---------------------------------------------------------------------------------------------
 sdram_initialization  = True
 sdram_write_training  = False
-sdram_read_training   = True
-sdram_test            = False
+sdram_read_training   = False
+sdram_test            = True
 
 # Parameters----------------------------------------------------------------------------------------
 
@@ -65,6 +65,14 @@ def ddram_set_bitslip(bitslip):
             wb.regs.ddrphy_rdly_dq_bitslip.write(1)
         wb.regs.ddrphy_dly_sel.write(0)
 
+
+def ddram_set_rdelay(rdelay):
+    for i in range(NBMODULES):
+        wb.regs.ddrphy_dly_sel.write(1<<i)
+        wb.regs.ddrphy_rdly_dq_rst.write(1)
+        for i in range(rdelay):
+            wb.regs.ddrphy_rdly_dq_inc.write(1)
+        wb.regs.ddrphy_dly_sel.write(0)
 
 # software control
 ddram_software_control()
@@ -220,6 +228,8 @@ if sdram_read_training:
 # DDRAM Test----------------------------------------------------------------------------------------
 
 if sdram_test:
+
+    ddram_set_rdelay(0x1A)
 
     # hardware control
     ddram_hardware_control()

--- a/test/test_sdram.py
+++ b/test/test_sdram.py
@@ -197,13 +197,13 @@ if sdram_read_training:
                     command_prd(0, 0, dfii_command_cas|dfii_command_cs|dfii_command_rddata)
                     p0 = wb.regs.sdram_dfii_pi0_rddata.read()
                     p1 = wb.regs.sdram_dfii_pi1_rddata.read()
-                    for j in range(8):
+                    for j in range(16):
                         dq = 0
-                        dq |= (p1 >> (8 + j)) & 0b1
+                        dq |= (p1 >> (16 + j)) & 0b1
                         dq <<= 1
                         dq |= (p1 >> (0 + j)) & 0b1
                         dq <<= 1
-                        dq |= (p0 >> (8 + j)) & 0b1
+                        dq |= (p0 >> (16 + j)) & 0b1
                         dq <<= 1
                         dq |= (p0 >> (0 + j)) & 0b1
                         print("dq{:d}: 0b{:08b}, ".format(j, dq), end="")

--- a/test/test_sdram.py
+++ b/test/test_sdram.py
@@ -192,7 +192,7 @@ if sdram_read_training:
             ddram_set_bitslip(0)
             self.enable_mpr()
             for i in range(NDELAYS):
-                for k in range(5):
+                for k in range(7):
                     print("delay: {} |".format(i), end="")
                     command_prd(0, 0, dfii_command_cas|dfii_command_cs|dfii_command_rddata)
                     p0 = wb.regs.sdram_dfii_pi0_rddata.read()
@@ -208,8 +208,8 @@ if sdram_read_training:
                         dq |= (p0 >> (0 + j)) & 0b1
                         print("dq{:d}: 0b{:08b}, ".format(j, dq), end="")
                     print("")
-                for i in range(NBMODULES):
-                    wb.regs.ddrphy_dly_sel.write(1 << i)
+                for j in range(NBMODULES):
+                    wb.regs.ddrphy_dly_sel.write(1 << j)
                     wb.regs.ddrphy_rdly_dq_inc.write(1)
                     wb.regs.ddrphy_dly_sel.write(0)
             self.disable_mpr()

--- a/test/test_sdram.py
+++ b/test/test_sdram.py
@@ -219,7 +219,7 @@ if sdram_read_training:
 # DDRAM Test----------------------------------------------------------------------------------------
 
 if sdram_test:
-    ddram_set_bitslip(2)
+    ddram_set_bitslip(0)
 
     # hardware control
     ddram_hardware_control()

--- a/test/test_sdram.py
+++ b/test/test_sdram.py
@@ -211,7 +211,7 @@ if sdram_read_training:
                     dq <<= 1
                     dq |= (p0 >> (0 + j)) & 0b1
                     print("dq{:d}: 0b{:08b}, ".format(j, dq), end="")
-                print(" | burst_det : %d" %wb.regs.ddrphy_burstdet_found.read())
+                print(" | burst_det : %d" %wb.regs.ddrphy_burstdet_count.read())
 
             for j in range(N_BYTE_GROUPS):
                 wb.regs.ddrphy_dly_sel.write(1 << j)
@@ -226,8 +226,8 @@ if sdram_read_training:
 
 if sdram_test:
 
-    ddram_set_rdelay(31)
-    ddram_set_bitslip(0)
+    ddram_set_rdelay(25)
+    ddram_set_bitslip(1)
 
     # hardware control
     ddram_hardware_control()

--- a/test/test_sdram.py
+++ b/test/test_sdram.py
@@ -19,7 +19,7 @@ sdram_test            = False
 # Parameters----------------------------------------------------------------------------------------
 
 NBMODULES = 1
-NDELAYS   = 64
+NDELAYS   = 8
 
 # MPR
 MPR_PATTERN = 0b01010101
@@ -184,26 +184,27 @@ if sdram_read_training:
 
         def run(self):
             print("Read leveling...")
-            #ddram_reset_rdelays()
+            ddram_reset_rdelays()
             #ddram_reset_wdelays()
             ddram_set_bitslip(0)
             self.enable_mpr()
             for i in range(NDELAYS):
-                print("delay: {} |".format(i), end="")
-                command_prd(0, 0, dfii_command_cas|dfii_command_cs|dfii_command_rddata)
-                p0 = wb.regs.sdram_dfii_pi0_rddata.read()
-                p1 = wb.regs.sdram_dfii_pi1_rddata.read()
-                for j in range(8):
-                    dq = 0
-                    dq |= (p1 >> (8 + j)) & 0b1
-                    dq <<= 1
-                    dq |= (p1 >> (0 + j)) & 0b1
-                    dq <<= 1
-                    dq |= (p0 >> (8 + j)) & 0b1
-                    dq <<= 1
-                    dq |= (p0 >> (0 + j)) & 0b1
-                    print("dq{:d}: 0b{:08b}, ".format(j, dq), end="")
-                print("")
+                for k in range(10):
+                    print("delay: {} |".format(i), end="")
+                    command_prd(0, 0, dfii_command_cas|dfii_command_cs|dfii_command_rddata)
+                    p0 = wb.regs.sdram_dfii_pi0_rddata.read()
+                    p1 = wb.regs.sdram_dfii_pi1_rddata.read()
+                    for j in range(8):
+                        dq = 0
+                        dq |= (p1 >> (8 + j)) & 0b1
+                        dq <<= 1
+                        dq |= (p1 >> (0 + j)) & 0b1
+                        dq <<= 1
+                        dq |= (p0 >> (8 + j)) & 0b1
+                        dq <<= 1
+                        dq |= (p0 >> (0 + j)) & 0b1
+                        print("dq{:d}: 0b{:08b}, ".format(j, dq), end="")
+                    print("")
                 for i in range(NBMODULES):
                     wb.regs.ddrphy_dly_sel.write(1 << i)
                     wb.regs.ddrphy_rdly_dq_inc.write(1)

--- a/test/test_sdram.py
+++ b/test/test_sdram.py
@@ -19,7 +19,7 @@ sdram_test            = False
 # Parameters----------------------------------------------------------------------------------------
 
 NBMODULES = 1
-NDELAYS   = 8
+NDELAYS   = 128
 
 # MPR
 MPR_PATTERN = 0b01010101
@@ -49,11 +49,13 @@ def ddram_reset_wdelays():
         wb.regs.ddrphy_wdly_dqs_rst.write(1)
         for j in range(wb.regs.ddrphy_half_sys8x_taps.read()):
             wb.regs.ddrphy_wdly_dqs_inc.write(1)
+        wb.regs.ddrphy_dly_sel.write(0)
 
 def ddram_reset_rdelays():
     for i in range(NBMODULES):
         wb.regs.ddrphy_dly_sel.write(1<<i)
         wb.regs.ddrphy_rdly_dq_rst.write(1)
+        wb.regs.ddrphy_dly_sel.write(0)
 
 def ddram_set_bitslip(bitslip):
     for i in range(NBMODULES):
@@ -61,6 +63,7 @@ def ddram_set_bitslip(bitslip):
         wb.regs.ddrphy_rdly_dq_bitslip_rst.write(1)
         for i in range(bitslip):
             wb.regs.ddrphy_rdly_dq_bitslip.write(1)
+        wb.regs.ddrphy_dly_sel.write(0)
 
 
 # software control
@@ -189,7 +192,7 @@ if sdram_read_training:
             ddram_set_bitslip(0)
             self.enable_mpr()
             for i in range(NDELAYS):
-                for k in range(10):
+                for k in range(5):
                     print("delay: {} |".format(i), end="")
                     command_prd(0, 0, dfii_command_cas|dfii_command_cs|dfii_command_rddata)
                     p0 = wb.regs.sdram_dfii_pi0_rddata.read()
@@ -208,6 +211,7 @@ if sdram_read_training:
                 for i in range(NBMODULES):
                     wb.regs.ddrphy_dly_sel.write(1 << i)
                     wb.regs.ddrphy_rdly_dq_inc.write(1)
+                    wb.regs.ddrphy_dly_sel.write(0)
             self.disable_mpr()
 
     ddram_leveling = DDRAMReadLeveling()

--- a/test/test_sdram.py
+++ b/test/test_sdram.py
@@ -226,8 +226,8 @@ if sdram_read_training:
 
 if sdram_test:
 
-    ddram_set_rdelay(25)
-    ddram_set_bitslip(1)
+    ddram_set_rdelay(26)
+    ddram_set_bitslip(0)
 
     # hardware control
     ddram_hardware_control()
@@ -258,6 +258,7 @@ if sdram_test:
 
     write_pattern(64)
     check_pattern(64, debug=True)
+
 
 # # #
 

--- a/versa_ecp5.py
+++ b/versa_ecp5.py
@@ -96,7 +96,7 @@ class BaseSoC(SoCSDRAM):
     def __init__(self, with_cpu=False, **kwargs):
         platform = versa_ecp5.Platform(toolchain="diamond")
         platform.add_extension(_ddram_io)
-        sys_clk_freq = int(50e6)
+        sys_clk_freq = int(100e6)
         SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq,
                           cpu_type="picorv32" if with_cpu else None, l2_size=32,
                           integrated_rom_size=0x8000 if with_cpu else 0,

--- a/versa_ecp5.py
+++ b/versa_ecp5.py
@@ -136,8 +136,12 @@ class BaseSoC(SoCSDRAM):
         if not with_cpu:
             analyzer_signals = [
                 self.ddrphy.dfi.p0,
-                self.ddrphy.dq_i_data
+                self.ddrphy.datavalid,
+                self.ddrphy.burstdet,
+                self.ddrphy.dqs_read,
+                self.ddrphy.readposition
             ]
+            analyzer_signals += [self.ddrphy.dq_i_data[i] for i in range(8)]
             self.submodules.analyzer = LiteScopeAnalyzer(analyzer_signals, 128)
 
     def generate_sdram_phy_py_header(self):

--- a/versa_ecp5.py
+++ b/versa_ecp5.py
@@ -67,8 +67,9 @@ class MT41K64M16(SDRAMModule):
 
 class _CRG(Module):
     def __init__(self, platform, sys_clk_freq):
+        self.clock_domains.cd_startclk = ClockDomain()
         self.clock_domains.cd_sys = ClockDomain()
-        self.clock_domains.cd_sys2x = ClockDomain(reset_less=True)
+        self.clock_domains.cd_sys2x = ClockDomain()
         self.clock_domains.cd_sys2x_i = ClockDomain(reset_less=True)
 
         # # #
@@ -78,14 +79,123 @@ class _CRG(Module):
         rst_n = platform.request("rst_n")
         platform.add_period_constraint(clk100, 10.0)
 
+        uddcntln = Signal(reset=0b1)
+        stop = Signal()
+        dll_lock = Signal()
+        freeze = Signal()
+        pause = Signal()
+        ddr_rst = Signal()
         # pll
         self.submodules.pll = pll = ECP5PLL()
         pll.register_clkin(clk100, 100e6)
         pll.create_clkout(self.cd_sys2x_i, 2*sys_clk_freq)
-        self.specials += Instance("ECLKSYNCB", i_ECLKI=self.cd_sys2x_i.clk, i_STOP=0, o_ECLKO=self.cd_sys2x.clk)
-        self.specials += Instance("CLKDIVF", p_DIV="2.0", i_CLKI=self.cd_sys2x.clk, i_RST=0, i_ALIGNWD=0, o_CDIVX=self.cd_sys.clk)
+        pll.create_clkout(self.cd_startclk, 25e6)
+        self.specials += Instance("ECLKSYNCB", i_ECLKI=self.cd_sys2x_i.clk, i_STOP=stop, o_ECLKO=self.cd_sys2x.clk)
+        self.specials += Instance("CLKDIVF", p_DIV="2.0", i_CLKI=self.cd_sys2x.clk, i_RST=self.cd_sys2x.rst, i_ALIGNWD=0, o_CDIVX=self.cd_sys.clk)
+
+        # Reset/init control
+        self.specials += AsyncResetSynchronizer(self.cd_startclk, ~pll.locked | ~rst_n)
         self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll.locked | ~rst_n)
 
+        # Synchronise DDRDLL lock
+        dll_lock_sync = Signal(2, reset=0b00)
+        self.sync.startclk += dll_lock_sync.eq(Cat(dll_lock, dll_lock_sync[0]))
+
+        # Reset & startup FSM
+        init_timer = Signal(4, reset=0b0000)
+        reset_ddr_done = Signal(reset=0b0)
+        uddcntln_done = Signal(reset=0b0)
+
+        fsm = ClockDomainsRenamer("startclk")(FSM(reset_state="WAIT_LOCK"))
+        self.submodules += fsm
+        fsm.act("WAIT_LOCK",
+            uddcntln.eq(1), stop.eq(0), pause.eq(0),
+            freeze.eq(0), ddr_rst.eq(0),
+            If(dll_lock_sync[1],
+                If(init_timer == 5,
+                    NextValue(init_timer, 0),
+                    If(uddcntln_done, NextState("READY"))
+                    .Elif(reset_ddr_done, NextState("PAUSE"))
+                    .Else(NextState("FREEZE"))
+                ).Else(
+                    NextValue(init_timer, init_timer + 1)
+                )
+            ).Else(
+                NextValue(init_timer, 0)
+            )
+        )
+        fsm.act("FREEZE", 
+            uddcntln.eq(1), stop.eq(0), pause.eq(0),
+            freeze.eq(1), ddr_rst.eq(0),
+            If(init_timer == 3,
+                NextValue(init_timer, 0),
+                If(reset_ddr_done, NextState("WAIT_LOCK"))
+                .Else(NextState("STOP"))
+            ).Else(
+                NextValue(init_timer, init_timer + 1)
+            )
+        )
+        fsm.act("STOP", 
+            uddcntln.eq(1), stop.eq(1), pause.eq(0),
+            freeze.eq(1), ddr_rst.eq(0),
+            If(init_timer == 3,
+                NextValue(init_timer, 0),
+                If(reset_ddr_done, NextState("FREEZE"))
+                .Else(NextState("RESET_DDR"))
+            ).Else(
+                NextValue(init_timer, init_timer + 1)
+            )
+        )
+        fsm.act("RESET_DDR", 
+            uddcntln.eq(1), stop.eq(1), pause.eq(0),
+            freeze.eq(1), ddr_rst.eq(1),
+            If(init_timer == 3,
+                NextValue(init_timer, 0),
+                NextValue(reset_ddr_done, 1),
+                NextState("STOP")
+            ).Else(
+                NextValue(init_timer, init_timer + 1)
+            )
+        )
+        fsm.act("PAUSE", 
+            uddcntln.eq(1), stop.eq(0), pause.eq(1),
+            freeze.eq(0), ddr_rst.eq(0),
+            If(init_timer == 3,
+                NextValue(init_timer, 0),
+                If(uddcntln_done, NextState("WAIT_LOCK"))
+                .Else(NextState("UDDCNTLN"))
+            ).Else(
+                NextValue(init_timer, init_timer + 1)
+            )
+        )
+        fsm.act("UDDCNTLN", 
+            uddcntln.eq(0), stop.eq(0), pause.eq(1),
+            freeze.eq(0), ddr_rst.eq(0),
+            If(init_timer == 3,
+                NextValue(init_timer, 0),
+                NextValue(uddcntln_done, 1),
+                NextState("PAUSE")
+            ).Else(
+                NextValue(init_timer, init_timer + 1)
+            )
+        )
+        fsm.act("READY", 
+            uddcntln.eq(1), stop.eq(0), pause.eq(0),
+            freeze.eq(0), ddr_rst.eq(0)
+        )
+        self.pause = pause
+        self.ddrdel = Signal()
+
+        self.specials += Instance("DDRDLLA",
+            i_CLK=self.cd_sys2x.clk,
+            i_RST=self.cd_startclk.rst,
+            i_UDDCNTLN=uddcntln,
+            i_FREEZE=freeze,
+            o_DDRDEL=self.ddrdel,
+            o_LOCK=dll_lock
+        )
+
+        self.sync.startclk += self.cd_sys2x.rst.eq(ddr_rst)
 
 class BaseSoC(SoCSDRAM):
     csr_map = {
@@ -106,7 +216,8 @@ class BaseSoC(SoCSDRAM):
                           **kwargs)
 
         # crg
-        self.submodules.crg = _CRG(platform, sys_clk_freq)
+        crg = _CRG(platform, sys_clk_freq)
+        self.submodules.crg = crg
 
         # uart
         if not with_cpu:
@@ -116,6 +227,7 @@ class BaseSoC(SoCSDRAM):
         # sdram
         self.submodules.ddrphy = ecp5ddrphy.ECP5DDRPHY(
             platform.request("ddram"),
+            pause=crg.pause, ddrdel=crg.ddrdel,
             sys_clk_freq=sys_clk_freq)
         sdram_module = MT41K64M16(sys_clk_freq, "1:2")
         self.register_sdram(self.ddrphy,

--- a/versa_ecp5.py
+++ b/versa_ecp5.py
@@ -96,7 +96,7 @@ class BaseSoC(SoCSDRAM):
     def __init__(self, with_cpu=False, **kwargs):
         platform = versa_ecp5.Platform(toolchain="diamond")
         platform.add_extension(_ddram_io)
-        sys_clk_freq = int(100e6)
+        sys_clk_freq = int(50e6)
         SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq,
                           cpu_type="picorv32" if with_cpu else None, l2_size=32,
                           integrated_rom_size=0x8000 if with_cpu else 0,
@@ -117,7 +117,7 @@ class BaseSoC(SoCSDRAM):
         self.submodules.ddrphy = ecp5ddrphy.ECP5DDRPHY(
             platform.request("ddram"),
             sys_clk_freq=sys_clk_freq)
-        sdram_module = MT41K64M16(sys_clk_freq, "1:4")
+        sdram_module = MT41K64M16(sys_clk_freq, "1:2")
         self.register_sdram(self.ddrphy,
             sdram_module.geom_settings,
             sdram_module.timing_settings)

--- a/versa_ecp5.py
+++ b/versa_ecp5.py
@@ -37,7 +37,7 @@ _ddram_io = [
             "D1 C1 E2 C2 F3 A2 E1 B1"),
             IOStandard("SSTL135_I"),
             Misc("TERMINATION=75")),
-        Subsignal("dqs_p", Pins("K2 H4"), IOStandard("SSTL135D_I")),
+        Subsignal("dqs_p", Pins("K2 H4"), IOStandard("SSTL135D_I"), Misc("TERMINATION=OFF"), Misc("DIFFRESISTOR=100")),
         Subsignal("dqs_n", Pins("J1 G5"), IOStandard("SSTL135D_I")),
         Subsignal("clk_p", Pins("M4"), IOStandard("SSTL135D_I")),
         Subsignal("clk_n", Pins("N5"), IOStandard("SSTL135D_I")),


### PR DESCRIPTION
 - Add DDRDEL & DELAYF
 - Dynamic READCLKSEL adjustment
 - Enable differential termination on DQS according to Lattice provided LPF

Not sure how correct all of this is, but I now seem to see the training pattern on some of the DQs (but for some reason not all) consistently